### PR TITLE
Stop BITBOX from mangling SLP OP_RETURN

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -28,9 +28,9 @@ function isPushOnly(value) {
 
 function asMinimalOP(buffer) {
   if (buffer.length === 0) return OPS.OP_0;
-  if (buffer.length !== 1) return;
-  if (buffer[0] >= 1 && buffer[0] <= 16) return OP_INT_BASE + buffer[0];
-  if (buffer[0] === 0x81) return OPS.OP_1NEGATE;
+  // if (buffer.length !== 1) return;
+  // if (buffer[0] >= 1 && buffer[0] <= 16) return OP_INT_BASE + buffer[0];
+  // if (buffer[0] === 0x81) return OPS.OP_1NEGATE;
 }
 
 function compile(chunks) {


### PR DESCRIPTION
This PR prevents the BITBOX Script class from mangling the SLP OP_RETURN. Specifically, the `BITBOX.Script.compile()` function. 

The current implementation, when presented with `0x01` hex in a Buffer, will replace it with `0x51`, which is `OP_1` in BTC. This PR prevents it from doing that.

There is a unit test that I could include with this PR, but this repo is badly neglected and I couldn't get tests to run as-is. I decided to opt for a PR with minimal changes.