### PR TITLE
Update crypto.ripemd160 method to use full algorithm name when alias not available

### DIFF
--- a/src/crypto.js
+++ b/src/crypto.js
@@ -1,7 +1,18 @@
 var createHash = require('create-hash')
 
+let ripemd160_str;
+try {
+  ripemd160_str = require('crypto')
+    .getHashes()
+    .includes('rmd160')
+    ? 'rmd160'
+    : 'ripemd160';
+} catch (err) {
+  ripemd160_str = 'rmd160';
+}
+
 function ripemd160 (buffer) {
-  return createHash('rmd160').update(buffer).digest()
+  return createHash(ripemd160_str).update(buffer).digest()
 }
 
 function sha1 (buffer) {


### PR DESCRIPTION
There is an issue with using the alias `rmd160` with Electron, and the developers suggest to use the full algorithm name `ripemd160` instead of fixing it in Electron itself.
https://github.com/electron/electron/issues/16195#issuecomment-477660937

The same fix is also applied to `bitcoinjs`.
https://github.com/bitcoinjs/bip32/pull/16