### PR TITLE
Fix OP_RETURN check

### DIFF
--- a/src/templates/nulldata.js
+++ b/src/templates/nulldata.js
@@ -8,7 +8,7 @@ var OPS = require('bitcoincash-ops')
 function check (script) {
   var buffer = bscript.compile(script)
 
-  return buffer.length > 1 &&
+  return buffer.length >= 1 &&
     buffer[0] === OPS.OP_RETURN
 }
 check.toJSON = function () { return 'null data output' }


### PR DESCRIPTION
Seems like the script can have `OP_RETURN` followed by nothing like in this [tx](https://bch.btc.com/1d6b942ebf4d0d6dd7a4baf83af3c03d2b64b91b9369794c25fdcffa851ed9cb).